### PR TITLE
Prosemirror for talents

### DIFF
--- a/system/templates/item/item-talent-sheet.hbs
+++ b/system/templates/item/item-talent-sheet.hbs
@@ -24,7 +24,7 @@
                 <span class="right-slope olive"></span>
             </div>
 
-            {{editor descriptionHTML target="system.description" rollData=rollData button=true owner=owner editable=editable}}
+            {{editor descriptionHTML target="system.description" rollData=rollData button=true owner=owner editable=editable engine="prosemirror"}}
 
         </div>
     </section>


### PR DESCRIPTION
Some talents requires the cthulhu icon included in the system font AC Cthullhu Icons, but the description editor is tinymce, which does not allow to change font, this fix replaces it for prosemirror:

And adding the font to the world custom font setting allows to insert icons:

![](https://i.ibb.co/N3LJK2f/talento.jpg)