### PR TITLE
Added Venomous weapon quality

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -408,6 +408,7 @@ AC2D20.Tooltips.WeaponQuality.parrying: When the weapon’s wielder makes an opp
 AC2D20.Tooltips.WeaponQuality.reliable: You may ignore the first complication rolled using this weapon in an action scene.
 AC2D20.Tooltips.WeaponQuality.subtle: Attacks with this weapon are difficult to hear, requiring a difficulty 2 <strong>Insight + Observation</strong> test to notice. The GM may adjust this difficulty based on distance and ambient noise.
 AC2D20.Tooltips.WeaponQuality.unreliable: Attacks with this weapon increase the test’s complication range by 1.
+AC2D20.Tooltips.WeaponQuality.venomous: "An Ophidian weapon with the Venomous trait which rolls one or more effects on damage will inflict the Poisoned truth on the target (or the Poisoned: Ophidian Toxins truth p.79). They will suffer Persistent 1 damage with a Piercing 2 effect every turn until cured. Due to the technology involved in their creation, Ophidian Venomous Weapons have a distinctive red flash when they fire, making them easy to spot and revealing the shooter’s location."
 AC2D20.UI.Add: Add
 AC2D20.UI.CarryWeight: Carry Weight
 AC2D20.UI.Cost: Cost
@@ -466,6 +467,7 @@ AC2D20.WEAPONS.weaponQuality.parrying: Parrying
 AC2D20.WEAPONS.weaponQuality.reliable: Reliable
 AC2D20.WEAPONS.weaponQuality.subtle: Subtle
 AC2D20.WEAPONS.weaponQuality.unreliable: Unreliable
+AC2D20.WEAPONS.weaponQuality.venomous: Venomous
 AC2D20.WEAPONS.weaponTypes.agi: Melee
 AC2D20.WEAPONS.weaponTypes.coo: Ranged
 AC2D20.WEAPONS.weaponTypes.Melee: Melee

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -408,6 +408,7 @@ AC2D20.Tooltips.WeaponQuality.parrying: When the weapon’s wielder makes an opp
 AC2D20.Tooltips.WeaponQuality.reliable: You may ignore the first complication rolled using this weapon in an action scene.
 AC2D20.Tooltips.WeaponQuality.subtle: Attacks with this weapon are difficult to hear, requiring a difficulty 2 <strong>Insight + Observation</strong> test to notice. The GM may adjust this difficulty based on distance and ambient noise.
 AC2D20.Tooltips.WeaponQuality.unreliable: Attacks with this weapon increase the test’s complication range by 1.
+AC2D20.Tooltips.WeaponQuality.venomous: "Un arma ofidia con el rasgo Venenosa que tira en el daño uno o más dados de efecto causará la verdad Envenenado en el objetivo (o la verdad Envenenado: toxinas ofidias p.79). Sufrirán daño Persistente 1 con efecto Perforante 2 cada turno hasta que sean curados. Debido a la tecnología empleada en su creación, las armas ofidias venenosas muestran un fogonazo rojo cuando las disparan, haciendo que sea fácil ver la procedencia y revelando la localización del tirador."
 AC2D20.UI.Add: Añadir
 AC2D20.UI.CarryWeight: Peso acarreado
 AC2D20.UI.Cost: Coste
@@ -466,6 +467,7 @@ AC2D20.WEAPONS.weaponQuality.parrying: Parada
 AC2D20.WEAPONS.weaponQuality.reliable: Fiable
 AC2D20.WEAPONS.weaponQuality.subtle: Sutil
 AC2D20.WEAPONS.weaponQuality.unreliable: Defectuosa
+AC2D20.WEAPONS.weaponQuality.venomous: Venenosa
 AC2D20.WEAPONS.weaponTypes.agi: Cuerpo a cuerpo
 AC2D20.WEAPONS.weaponTypes.coo: Distancia
 AC2D20.WEAPONS.weaponTypes.Melee: Cuerpo a cuerpo

--- a/system/src/config.mjs
+++ b/system/src/config.mjs
@@ -76,6 +76,7 @@ AC2D20.WEAPON_QUALITIES = {
 	reliable: "AC2D20.WEAPONS.weaponQuality.reliable",
 	subtle: "AC2D20.WEAPONS.weaponQuality.subtle",
 	unreliable: "AC2D20.WEAPONS.weaponQuality.unreliable",
+	venomous: "AC2D20.WEAPONS.weaponQuality.venomous",
 };
 
 AC2D20.WEAPONS = {

--- a/system/template.json
+++ b/system/template.json
@@ -390,6 +390,9 @@
 				},
 				"unreliable": {
 					"value": false
+				},
+				"venomous": {
+					"value": false
 				}
 			},
 			"range": "close",


### PR DESCRIPTION
The  Serpent & the sands adds a new trait for weapons;

> Venomous Weapons
> An Ophidian weapon with the Venomous trait which rolls one or more effects on damage will inflict the Poisoned truth on the target (or the Poisoned: Ophidian Toxins truth p.79). They will suffer Persistent 1 damage with a Piercing 2 effect every turn until cured. Due to the technology involved in their creation, Ophidian Venomous Weapons have a distinctive red flash when they fire, making them easy to spot and revealing the shooter’s location.

I've added it as a new quality, feel free to change it.

![image](https://i.ibb.co/PcTyCp6/Captura-de-pantalla-2024-08-29-111233.jpg)
